### PR TITLE
Fix minecraft path for mac (#1)

### DIFF
--- a/src/main/java/cpw/mods/fml/installer/SimpleInstaller.java
+++ b/src/main/java/cpw/mods/fml/installer/SimpleInstaller.java
@@ -31,7 +31,7 @@ public class SimpleInstaller {
         }
         else if (osType.contains("mac"))
         {
-            targetDir = new File(new File(new File(userHomeDir, "Library"),"Application Support"),mcDir);
+            targetDir = new File(new File(new File(userHomeDir, "Library"),"Application Support"),"minecraft");
         }
         else
         {


### PR DESCRIPTION
On macs, the minecraft dir is ~/Library/Application Support/minecraft, not ~/Library/Application Support/.minecraft
