### PR TITLE
Fix libs contents inconsistent between installation

### DIFF
--- a/src/main/java/net/minecraftforge/installer/DownloadUtils.java
+++ b/src/main/java/net/minecraftforge/installer/DownloadUtils.java
@@ -263,7 +263,9 @@ public class DownloadUtils {
 
         Pack200.newUnpacker().unpack(temp, jos);
 
-        jos.putNextEntry(new JarEntry("checksums.sha1"));
+        JarEntry checksumsFile = new JarEntry("checksums.sha1");
+        checksumsFile.setTime(0);
+        jos.putNextEntry(checksumsFile);
         jos.write(checksums);
         jos.closeEntry();
 


### PR DESCRIPTION
Currently installer does not set 'last modified' time on `checksums.sha1` file added to certain downloaded libs. This causes every installation to contain files with same content, but different checksums. Such behaviour breaks checksum-sensitive tools (or at least generates lots of junk and duplicates).