### PR TITLE
Clean up logging, pipe processor stdout to ProgressCallback

### DIFF
--- a/src/main/java/net/minecraftforge/installer/ProgressFrame.java
+++ b/src/main/java/net/minecraftforge/installer/ProgressFrame.java
@@ -19,6 +19,8 @@ import net.minecraftforge.installer.actions.ProgressCallback;
 public class ProgressFrame extends JFrame implements ProgressCallback
 {
     private static final long serialVersionUID = 1L;
+    
+    private final ProgressCallback parent;
 
     private final JPanel panel = new JPanel();
 
@@ -26,8 +28,10 @@ public class ProgressFrame extends JFrame implements ProgressCallback
     private final JProgressBar progressBar;
     private final JTextArea consoleArea;
 
-    public ProgressFrame(String title, Runnable canceler)
+    public ProgressFrame(ProgressCallback parent, String title, Runnable canceler)
     {
+        this.parent = parent;
+        
         setResizable(false);
         setTitle(title);
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -89,14 +93,14 @@ public class ProgressFrame extends JFrame implements ProgressCallback
         message(label, MessagePriority.HIGH);
         this.progressBar.setValue(0);
         this.progressBar.setIndeterminate(false);
-        ProgressCallback.super.start(label);
+        parent.start(label);
     }
 
     @Override
     public void progress(double progress)
     {
         this.progressBar.setValue((int) (progress * 100));
-        ProgressCallback.super.progress(progress);
+        parent.progress(progress);
     }
 
     @Override
@@ -104,7 +108,7 @@ public class ProgressFrame extends JFrame implements ProgressCallback
     {
         message(message, MessagePriority.HIGH);
         this.progressBar.setIndeterminate(true);
-        ProgressCallback.super.stage(message);
+        parent.stage(message);
     }
 
     @Override
@@ -116,6 +120,6 @@ public class ProgressFrame extends JFrame implements ProgressCallback
         }
         consoleArea.append(message + "\n");
         consoleArea.setCaretPosition(consoleArea.getDocument().getLength());
-        ProgressCallback.super.message(message, priority);
+        parent.message(message, priority);
     }
 }

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -34,7 +34,8 @@ public class SimpleInstaller
         }
         catch (FileNotFoundException e)
         {
-            monitor = ProgressCallback.TO_STD_OUT;
+            e.printStackTrace();
+            monitor = ProgressCallback.withOutputs(System.out);
         }
         
         if (System.getProperty("java.net.preferIPv4Stack") == null) //This is a dirty hack, but screw it, i'm hoping this as default will fix more things then it breaks.

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -30,13 +30,13 @@ public class SimpleInstaller
         try
         {
             monitor = ProgressCallback.withOutputs(System.out, getLog());
-            hookStdOut(monitor);
         }
         catch (FileNotFoundException e)
         {
             e.printStackTrace();
             monitor = ProgressCallback.withOutputs(System.out);
         }
+        hookStdOut(monitor);
         
         if (System.getProperty("java.net.preferIPv4Stack") == null) //This is a dirty hack, but screw it, i'm hoping this as default will fix more things then it breaks.
         {

--- a/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
+++ b/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
@@ -93,7 +93,7 @@ public class PostProcessors {
                 monitor.start("Building Processors");
             }
             for (Processor proc : processors) {
-                monitor.progress((double) progress / processors.size());
+                monitor.progress((double) progress++ / processors.size());
 
                 File jar = proc.getJar().getLocalPath(librariesDir);
                 if (!jar.exists() || !jar.isFile()) {


### PR DESCRIPTION
- `ProgressFrame` now has a "parent" `ProgressCallback` which is what handles stdout/.log output.
- `ProgressCallback` provides `withOutputs` to pipe to some `OutputStream`(s)
- stdout/stderr hook now just feeds into a `ProgressCallback`, and is updated to the GUI callback when that is open.