### PR TITLE
Fix installer using black text in install location text on dark theme

### DIFF
--- a/src/main/java/net/minecraftforge/installer/InstallerPanel.java
+++ b/src/main/java/net/minecraftforge/installer/InstallerPanel.java
@@ -379,7 +379,7 @@ public class InstallerPanel extends JPanel {
         }
         if (valid)
         {
-            selectedDirText.setForeground(Color.BLACK);
+            selectedDirText.setForeground(null);
             infoLabel.setVisible(false);
             fileEntryPanel.setBorder(null);
         }


### PR DESCRIPTION
A minor fix for GUI showing almost unreadable text when the swing system look and feel is dark, by using default color (`null`) instead of hardcoding `BLACK`.

Before:
![image](https://user-images.githubusercontent.com/1349112/52896063-d8123880-31c2-11e9-818b-cdc009ff64ff.png)
After:
![image](https://user-images.githubusercontent.com/1349112/52896080-0c85f480-31c3-11e9-9272-4c2fece05c62.png)
