### PR TITLE
Fix running the installer on Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
 
 dependencies {
     compile 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    compile 'com.google.code.gson:gson:2.8.5'
+    compile 'com.google.code.gson:gson:2.8.6'
 }
 
 compileJava {


### PR DESCRIPTION
EDIT: the installer itself does not crash, it's something else. But updating GSON can't harm either way.