### PR TITLE
Fix PostProcessor outputs Map parsing

### DIFF
--- a/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
+++ b/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
@@ -124,7 +124,7 @@ public class PostProcessors {
                         String key = e.getKey();
                         if (key.charAt(0) == '{' && key.charAt(key.length() - 1) == '}')
                             key = data.get(key.substring(1, key.length() - 1));
-                        else if (key.charAt(0) == '{' && key.charAt(key.length() - 1) == '}')
+                        else if (key.charAt(0) == '[' && key.charAt(key.length() - 1) == ']')
                             key = Artifact.from(key.substring(1, key.length() - 1)).getLocalPath(librariesDir).getAbsolutePath();
 
                         String value = e.getValue();


### PR DESCRIPTION
Just a trivial bug I noticed. This does not get exercised by current install profiles.