### PR TITLE
Fix HashFunction padding on some locales

### DIFF
--- a/src/main/java/net/minecraftforge/installer/HashFunction.java
+++ b/src/main/java/net/minecraftforge/installer/HashFunction.java
@@ -39,7 +39,8 @@ public enum HashFunction {
 
     private HashFunction(String algo, int length) {
         this.algo = algo;
-        this.pad = String.format("%0" + length + "d", 0);
+        // must specify locale to get correct number formatting
+        this.pad = String.format(Locale.ENGLISH, "%0" + length + "d", 0);
     }
 
     public String getExtension() {


### PR DESCRIPTION
String.format uses system locale, which can have special number formatting (specifically Hindi), causing HashFunction padding to be incorrect.