### PR TITLE
Add support for copying libraries from local minecraft install when installing server

### DIFF
--- a/src/main/java/net/minecraftforge/installer/DownloadUtils.java
+++ b/src/main/java/net/minecraftforge/installer/DownloadUtils.java
@@ -45,7 +45,7 @@ public class DownloadUtils {
 
     public static boolean OFFLINE_MODE = false;
 
-    public static boolean downloadLibrary(ProgressCallback monitor, Mirror mirror, Library library, File root, Predicate<String> optional, List<Artifact> grabbed) {
+    public static boolean downloadLibrary(ProgressCallback monitor, Mirror mirror, Library library, File root, Predicate<String> optional, List<Artifact> grabbed, List<File> additionalLibraryDirs) {
         Artifact artifact = library.getName();
         File target = artifact.getLocalPath(root);
         LibraryDownload download = library.getDownloads() == null ? null :  library.getDownloads().getArtifact();
@@ -112,6 +112,43 @@ public class DownloadUtils {
         } catch (IOException e) {
             e.printStackTrace();
             return false;
+        }
+
+        // Try searching local installs if the file can be validated
+        if (download.getSha1() != null) {
+            String providedSha1 = download.getSha1();
+            for (File libDir : additionalLibraryDirs) {
+                File inLibDir = new File(libDir, artifact.getPath());
+                if (inLibDir.exists()) {
+                    monitor.message(String.format("  Found artifact in local folder %s", libDir.toString()));
+                    String sha1 = DownloadUtils.getSha1(inLibDir);
+                    if (providedSha1.equals(sha1)) {
+                        monitor.message("    Checksum validated");
+                    } else {
+                        // Do not fail immediately. We may have other sources
+                        monitor.message("    Invalid checksum. Not using.");
+                        continue;
+                    }
+                    // Valid checksum, copy the lib
+                    try {
+                        Files.copy(inLibDir.toPath(), target.toPath());
+                        monitor.message("    Successfully copied local file");
+                        grabbed.add(artifact);
+                        return true;
+                    } catch (IOException e) {
+                        // The copy may have failed when the file is in use. Don't abort, we may have other sources
+                        e.printStackTrace();
+                        monitor.message(String.format("    Failed to copy from local folder: %s", e.toString()));
+                        // Clean up the file that may have been created if the copy failed
+                        if (target.exists()) {
+                            if (!target.delete()) {
+                                monitor.message("    Failed to delete failed copy, aborting");
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         String url = download.getUrl();

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -143,7 +143,7 @@ public class SimpleInstaller
             launchGui(monitor);
     }
 
-    private static File getMCDir()
+    public static File getMCDir()
     {
         String userHomeDir = System.getProperty("user.home", ".");
         String osType = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);

--- a/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
@@ -22,6 +22,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.function.Predicate;
 import net.minecraftforge.installer.DownloadUtils;
 import net.minecraftforge.installer.json.Install;
@@ -105,7 +106,7 @@ public class ClientInstall extends Action {
         }
 
         // Download Libraries
-        if (!downloadLibraries(librariesDir, optionals))
+        if (!downloadLibraries(librariesDir, optionals, new ArrayList<>()))
             return false;
         checkCancel();
 

--- a/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import net.minecraftforge.installer.DownloadUtils;
+import net.minecraftforge.installer.SimpleInstaller;
 import net.minecraftforge.installer.json.Artifact;
 import net.minecraftforge.installer.json.Install;
 import net.minecraftforge.installer.json.Util;
@@ -88,7 +89,12 @@ public class ServerInstall extends Action {
         checkCancel();
 
         // Download Libraries
-        if (!downloadLibraries(librariesDir, optionals))
+        List<File> libDirs = new ArrayList<>();
+        File mcLibDir = new File(SimpleInstaller.getMCDir(), "libraries");
+        if (mcLibDir.exists()) {
+            libDirs.add(mcLibDir);
+        }
+        if (!downloadLibraries(librariesDir, optionals, libDirs))
             return false;
 
         checkCancel();


### PR DESCRIPTION
This PR adds support for the Server Install to check if the required libraries already exist in the minecraft client install.
Also adds support for searching local m2, which is very useful when testing with custom libraries (like a custom forgeSPI version with a new API required for a PR).