### PR TITLE
Remove emptyFrame entirely, fixes #62

### DIFF
--- a/src/main/java/net/minecraftforge/installer/InstallerPanel.java
+++ b/src/main/java/net/minecraftforge/installer/InstallerPanel.java
@@ -405,11 +405,7 @@ public class InstallerPanel extends JPanel {
     {
         JOptionPane optionPane = new JOptionPane(this, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION);
 
-        Frame emptyFrame = new Frame("Mod system installer");
-        emptyFrame.setLocationRelativeTo(null);
-        emptyFrame.setUndecorated(true);
-        emptyFrame.setVisible(true);
-        dialog = optionPane.createDialog(emptyFrame, "Mod system installer");
+        dialog = optionPane.createDialog("Mod system installer");
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setVisible(true);
         int result = (Integer) (optionPane.getValue() != null ? optionPane.getValue() : -1);
@@ -441,7 +437,6 @@ public class InstallerPanel extends JPanel {
             }
         }
         dialog.dispose();
-        emptyFrame.dispose();
     }
 
     private void openURL(String url)


### PR DESCRIPTION
This PR removes the `emptyFrame` container that the optionPane uses as a parent. This fixes #62 as a result and also fixes the taskbar window preview.

Sm0keySa1m0n tested this and said they did not find any immediate issues when launching and running tasks. I've double checked and have come to the same conclusion myself. As for closing behaviour, it seems to properly terminate the java process after a short delay when closing the window either by clicking cancel or by the titlebar's close button.