### PR TITLE
add a flag to control the hash checking

### DIFF
--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -36,6 +36,7 @@ import net.minecraftforge.installer.json.Util;
 public class SimpleInstaller {
     public static boolean headless = false;
     public static boolean debug = false;
+    public static boolean skipHashCheck = false;
     public static URL mirror = null;
 
     public static void main(String[] args) throws IOException, URISyntaxException {
@@ -73,6 +74,7 @@ public class SimpleInstaller {
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"),"Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
         OptionSpec<Void> debugOption = parser.accepts("debug", "Run in debug mode -- don't delete any files");
+        OptionSpec<Void> skipHashCheckOption = parser.accepts("skipHashCheck", "skips the hash check when verifing outputs");
         OptionSpec<URL> mirrorOption = parser.accepts("mirror", "Use a specific mirror URL").withRequiredArg().ofType(URL.class);
         OptionSet optionSet = parser.parse(args);
 
@@ -84,6 +86,7 @@ public class SimpleInstaller {
         debug = optionSet.has(debugOption);
         if (optionSet.has(mirrorOption))
             mirror = optionSet.valueOf(mirrorOption);
+        skipHashCheck = optionSet.has(skipHashCheckOption);
 
         String badCerts = "";
         if (optionSet.has(offlineOption) || SimpleInstaller.class.getResource("/" + OfflineAction.OFFLINE_FLAG) != null) {

--- a/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
+++ b/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
@@ -234,7 +234,7 @@ public class PostProcessors {
                         ret.add(output.file);
                         if (!output.file.exists()) {
                             err.append("\n    ").append(output.file).append(" missing");
-                        } else {
+                        } else if (!SimpleInstaller.skipHashCheck) {
                             String sha = DownloadUtils.getSha1(output.file);
                             if (sha.equals(output.sha1)) {
                                 log("  Output: " + output.file + " Checksum Validated: " + sha);


### PR DESCRIPTION
Address the compatibility issue with zlib-ng-compat, which is now shipped in place of zlib in various Linux distros. This change introduces an option to disable hash mismatches reported on processors.
It doesn't need to be visible in the project, as I plan to integrate it with the [ForgeWrapper](https://github.com/ZekerZhayard/ForgeWrapper).