### PR TITLE
Explicitly set compression ratio on resulting jar files

### DIFF
--- a/src/main/java/net/minecraftforge/installer/actions/OfflineAction.java
+++ b/src/main/java/net/minecraftforge/installer/actions/OfflineAction.java
@@ -78,6 +78,9 @@ public class OfflineAction extends Action {
 
         checkCancel();
         try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(target))) {
+            // Explicitly set compression level because of potential differences based on environment.
+            // See https://github.com/MinecraftForge/JarSplitter/pull/2
+            zout.setLevel(6);
             Set<String> seen = new HashSet<>();
 
             // Copy our input installer jar


### PR DESCRIPTION
This is a follow-up from the discussion in: https://github.com/MinecraftForge/Installer/pull/77#issuecomment-2849379521
@LexManos, hopefully, this is what you wanted.
In the installer, this is the only ZipOutputStream instance.
If this should not be done here but in a different repo, let me know. I will try to adjust, as I do not fully grasp what needs to be done.
